### PR TITLE
Normalize Traccar base URL handling across backend

### DIFF
--- a/backend/src/realtime/traccarBridge.js
+++ b/backend/src/realtime/traccarBridge.js
@@ -3,10 +3,15 @@ import WebSocket from "ws";
 import https from "https";
 // import https from "https"; // se seu Traccar for HTTPS self-signed, veja o comentário mais abaixo
 
-const baseURL = process.env.TRACCAR_BASE_URL; // ex.: http://localhost:8082
+import { buildTraccarWsUrl, parseTraccarBaseUrl } from "../utils/traccarUrls.js";
+
+const baseURL = process.env.TRACCAR_BASE_URL; // ex.: http://localhost:8082 OU http://localhost:8082/api
 const user    = process.env.TRACCAR_USER;     // admin (ou outro)
 const pass    = process.env.TRACCAR_PASS;     // senha
+const token   = process.env.TRACCAR_TOKEN;    // alternativa usando token
 const allowSelfSigned = String(process.env.ALLOW_SELF_SIGNED || '') === 'true';
+
+const { httpBaseURL, apiBaseURL, error: baseUrlError } = parseTraccarBaseUrl(baseURL);
 
 // --- Registro dos clientes SSE do navegador
 const sseClients = new Set();
@@ -17,14 +22,6 @@ export function addSseClient(res) {
 function broadcast(type, payload) {
   const chunk = `event: ${type}\ndata: ${JSON.stringify(payload)}\n\n`;
   for (const res of sseClients) res.write(chunk);
-}
-
-function buildWsUrl(base) {
-  // remove barras finais
-  const trimmed = base.replace(/\/+$/, '');
-  const proto = trimmed.startsWith('https') ? 'wss' : 'ws';
-  const host  = trimmed.replace(/^https?:\/\//, '');
-  return `${proto}://${host}/api/socket`;
 }
 
 function logAxiosError(tag, e) {
@@ -39,60 +36,84 @@ let reconnectTimer;
 let backoff = 1000;
 
 async function createSession() {
-  const url = `${baseURL.replace(/\/+$/, '')}/api/session`;
+  if (!apiBaseURL) {
+    throw new Error("TRACCAR_BASE_URL inválido; não é possível montar URL da sessão");
+  }
+  const url = `${apiBaseURL}/session`;
   const httpsCfg = allowSelfSigned ? { httpsAgent: new https.Agent({ rejectUnauthorized: false }) } : {};
 
-  // 1) JSON
-  try {
-    const resp = await axios.post(
-      url,
-      { email: user, password: pass },
-      { headers: { "Content-Type": "application/json", Accept: "application/json" }, withCredentials: true, ...httpsCfg }
-    );
-    const cookie = resp.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
-    if (!cookie) throw new Error("Sessão sem JSESSIONID (JSON)");
-    return cookie.split(";")[0];
-  } catch (e) {
-    logAxiosError('session-json', e);
-    const status = e.response?.status;
-    if (status !== 400 && status !== 415) throw e;
+  if (user && pass) {
+    // 1) JSON
+    try {
+      const resp = await axios.post(
+        url,
+        { email: user, password: pass },
+        { headers: { "Content-Type": "application/json", Accept: "application/json" }, withCredentials: true, ...httpsCfg }
+      );
+      const cookie = resp.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
+      if (!cookie) throw new Error("Sessão sem JSESSIONID (JSON)");
+      return cookie.split(";")[0];
+    } catch (e) {
+      logAxiosError('session-json', e);
+      const status = e.response?.status;
+      if (status !== 400 && status !== 415) throw e;
+    }
+
+    // 2) x-www-form-urlencoded
+    try {
+      const form = new URLSearchParams({ email: user, password: pass });
+      const resp2 = await axios.post(url, form.toString(), {
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        withCredentials: true,
+        ...httpsCfg,
+      });
+      const cookie2 = resp2.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
+      if (!cookie2) throw new Error("Sessão sem JSESSIONID (form)");
+      return cookie2.split(";")[0];
+    } catch (e) {
+      logAxiosError('session-form', e);
+    }
+
+    // 3) Basic Auth
+    try {
+      const basic = Buffer.from(`${user}:${pass}`).toString("base64");
+      const resp3 = await axios.get(url, {
+        headers: { Authorization: `Basic ${basic}` },
+        withCredentials: true,
+        ...httpsCfg,
+      });
+      const cookie3 = resp3.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
+      if (!cookie3) throw new Error("Sessão sem JSESSIONID (basic)");
+      return cookie3.split(";")[0];
+    } catch (e) {
+      logAxiosError('session-basic', e);
+    }
   }
 
-  // 2) x-www-form-urlencoded
-  try {
-    const form = new URLSearchParams({ email: user, password: pass });
-    const resp2 = await axios.post(url, form.toString(), {
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      withCredentials: true,
-      ...httpsCfg,
-    });
-    const cookie2 = resp2.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
-    if (!cookie2) throw new Error("Sessão sem JSESSIONID (form)");
-    return cookie2.split(";")[0];
-  } catch (e) {
-    logAxiosError('session-form', e);
+  if (token) {
+    try {
+      const resp = await axios.get(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        withCredentials: true,
+        ...httpsCfg,
+      });
+      const cookie = resp.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
+      if (!cookie) throw new Error("Sessão sem JSESSIONID (token)");
+      return cookie.split(";")[0];
+    } catch (e) {
+      logAxiosError('session-token', e);
+    }
   }
 
-  // 3) Basic Auth
-  try {
-    const basic = Buffer.from(`${user}:${pass}`).toString("base64");
-    const resp3 = await axios.get(url, {
-      headers: { Authorization: `Basic ${basic}` },
-      withCredentials: true,
-      ...httpsCfg,
-    });
-    const cookie3 = resp3.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
-    if (!cookie3) throw new Error("Sessão sem JSESSIONID (basic)");
-    return cookie3.split(";")[0];
-  } catch (e) {
-    logAxiosError('session-basic', e);
-    throw e;
-  }
+  throw new Error("Não foi possível obter cookie de sessão do Traccar");
 }
 
 
 function openWs(cookie) {
-  const wsUrl = buildWsUrl(baseURL);
+  if (!httpBaseURL) {
+    throw new Error("TRACCAR_BASE_URL inválido; não é possível montar URL do WebSocket");
+  }
+  const wsUrl = buildTraccarWsUrl(httpBaseURL);
   const wsOpts = { headers: { Cookie: cookie } };
   if (allowSelfSigned) wsOpts.rejectUnauthorized = false;
 
@@ -139,9 +160,21 @@ function scheduleReconnect() {
 }
 
 export function startRealtimeBridge() {
-  if (!user || !pass) {
-    console.warn("TRACCAR_USER/TRACCAR_PASS não definidos; WS não será iniciado (REST continua funcionando).");
+  if (!baseURL) {
+    console.warn("TRACCAR_BASE_URL não definido; WS não será iniciado.");
     return;
   }
+
+  if (!httpBaseURL || !apiBaseURL) {
+    const extra = baseUrlError ? ` (${baseUrlError})` : "";
+    console.warn(`TRACCAR_BASE_URL inválido; informe algo como http://host:8082 ou http://host:8082/api.${extra}`);
+    return;
+  }
+
+  if (!((user && pass) || token)) {
+    console.warn("Credenciais do Traccar ausentes; defina TRACCAR_USER/TRACCAR_PASS ou TRACCAR_TOKEN para habilitar o WS.");
+    return;
+  }
+
   connect();
 }

--- a/backend/src/services/traccarClient.js
+++ b/backend/src/services/traccarClient.js
@@ -1,12 +1,24 @@
-﻿import axios from "axios";
+import axios from "axios";
 // import https from "https"; // se usar HTTPS self-signed, descomente o Agent abaixo
+
+import { parseTraccarBaseUrl } from "../utils/traccarUrls.js";
 
 const baseURL = process.env.TRACCAR_BASE_URL;
 const token   = process.env.TRACCAR_TOKEN;
 
+const { httpBaseURL, error: baseUrlError } = parseTraccarBaseUrl(baseURL);
+const axiosBaseURL = httpBaseURL ?? baseURL;
+
+if (!axiosBaseURL && baseUrlError) {
+  console.warn(`TRACCAR_BASE_URL inválido; informe algo como http://host:8082 ou http://host:8082/api. (${baseUrlError})`);
+}
+
+const headers = {};
+if (token) headers.Authorization = `Bearer ${token}`;
+
 export const traccar = axios.create({
-  baseURL,
-  headers: { Authorization: 'Bearer ' + token },
+  baseURL: axiosBaseURL,
+  headers,
   timeout: 10000,
   // httpsAgent: new https.Agent({ rejectUnauthorized: false }),
 });

--- a/backend/src/utils/traccarUrls.js
+++ b/backend/src/utils/traccarUrls.js
@@ -1,0 +1,50 @@
+export function parseTraccarBaseUrl(rawBaseURL) {
+  if (!rawBaseURL) {
+    return {
+      rawBaseURL,
+      trimmedBaseURL: undefined,
+      httpBaseURL: undefined,
+      apiBaseURL: undefined,
+      error: "TRACCAR_BASE_URL não definido",
+    };
+  }
+
+  const trimmedBaseURL = rawBaseURL.replace(/\/+$/, "");
+  const maybeHttpBase = trimmedBaseURL.endsWith("/api")
+    ? trimmedBaseURL.slice(0, -4)
+    : trimmedBaseURL;
+
+  try {
+    const parsed = new URL(maybeHttpBase);
+    if (!/^https?:$/.test(parsed.protocol)) {
+      throw new Error("Protocol must be http or https");
+    }
+
+    const normalizedPath = parsed.pathname.replace(/\/+$/, "");
+    const httpBaseURL = `${parsed.origin}${normalizedPath === "/" ? "" : normalizedPath}`;
+    const apiBaseURL = `${httpBaseURL}/api`;
+
+    return {
+      rawBaseURL,
+      trimmedBaseURL,
+      httpBaseURL,
+      apiBaseURL,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      rawBaseURL,
+      trimmedBaseURL,
+      httpBaseURL: undefined,
+      apiBaseURL: undefined,
+      error: err?.message || "URL inválida",
+    };
+  }
+}
+
+export function buildTraccarWsUrl(httpBaseURL) {
+  const trimmed = httpBaseURL.replace(/\/+$/, "");
+  const proto = trimmed.startsWith("https") ? "wss" : "ws";
+  const host = trimmed.replace(/^https?:\/\//, "");
+  return `${proto}://${host}/api/socket`;
+}


### PR DESCRIPTION
## Summary
- add a shared helper to normalize TRACCAR_BASE_URL and build the WebSocket endpoint
- reuse the helper in the realtime bridge and REST client to avoid double /api segments and improve logging
- avoid attaching an empty Bearer token header when none is configured

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3328abf648330b052e50f05e0f5b5