### PR TITLE
Add hierarchical auth system and user management UI

### DIFF
--- a/backend/src/realtime/traccarBridge.js
+++ b/backend/src/realtime/traccarBridge.js
@@ -3,10 +3,15 @@ import WebSocket from "ws";
 import https from "https";
 // import https from "https"; // se seu Traccar for HTTPS self-signed, veja o comentário mais abaixo
 
-const baseURL = process.env.TRACCAR_BASE_URL; // ex.: http://localhost:8082
+import { buildTraccarWsUrl, parseTraccarBaseUrl } from "../utils/traccarUrls.js";
+
+const baseURL = process.env.TRACCAR_BASE_URL; // ex.: http://localhost:8082 OU http://localhost:8082/api
 const user    = process.env.TRACCAR_USER;     // admin (ou outro)
 const pass    = process.env.TRACCAR_PASS;     // senha
+const token   = process.env.TRACCAR_TOKEN;    // alternativa usando token
 const allowSelfSigned = String(process.env.ALLOW_SELF_SIGNED || '') === 'true';
+
+const { httpBaseURL, apiBaseURL, error: baseUrlError } = parseTraccarBaseUrl(baseURL);
 
 // --- Registro dos clientes SSE do navegador
 const sseClients = new Set();
@@ -17,14 +22,6 @@ export function addSseClient(res) {
 function broadcast(type, payload) {
   const chunk = `event: ${type}\ndata: ${JSON.stringify(payload)}\n\n`;
   for (const res of sseClients) res.write(chunk);
-}
-
-function buildWsUrl(base) {
-  // remove barras finais
-  const trimmed = base.replace(/\/+$/, '');
-  const proto = trimmed.startsWith('https') ? 'wss' : 'ws';
-  const host  = trimmed.replace(/^https?:\/\//, '');
-  return `${proto}://${host}/api/socket`;
 }
 
 function logAxiosError(tag, e) {
@@ -39,60 +36,84 @@ let reconnectTimer;
 let backoff = 1000;
 
 async function createSession() {
-  const url = `${baseURL.replace(/\/+$/, '')}/api/session`;
+  if (!apiBaseURL) {
+    throw new Error("TRACCAR_BASE_URL inválido; não é possível montar URL da sessão");
+  }
+  const url = `${apiBaseURL}/session`;
   const httpsCfg = allowSelfSigned ? { httpsAgent: new https.Agent({ rejectUnauthorized: false }) } : {};
 
-  // 1) JSON
-  try {
-    const resp = await axios.post(
-      url,
-      { email: user, password: pass },
-      { headers: { "Content-Type": "application/json", Accept: "application/json" }, withCredentials: true, ...httpsCfg }
-    );
-    const cookie = resp.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
-    if (!cookie) throw new Error("Sessão sem JSESSIONID (JSON)");
-    return cookie.split(";")[0];
-  } catch (e) {
-    logAxiosError('session-json', e);
-    const status = e.response?.status;
-    if (status !== 400 && status !== 415) throw e;
+  if (user && pass) {
+    // 1) JSON
+    try {
+      const resp = await axios.post(
+        url,
+        { email: user, password: pass },
+        { headers: { "Content-Type": "application/json", Accept: "application/json" }, withCredentials: true, ...httpsCfg }
+      );
+      const cookie = resp.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
+      if (!cookie) throw new Error("Sessão sem JSESSIONID (JSON)");
+      return cookie.split(";")[0];
+    } catch (e) {
+      logAxiosError('session-json', e);
+      const status = e.response?.status;
+      if (status !== 400 && status !== 415) throw e;
+    }
+
+    // 2) x-www-form-urlencoded
+    try {
+      const form = new URLSearchParams({ email: user, password: pass });
+      const resp2 = await axios.post(url, form.toString(), {
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        withCredentials: true,
+        ...httpsCfg,
+      });
+      const cookie2 = resp2.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
+      if (!cookie2) throw new Error("Sessão sem JSESSIONID (form)");
+      return cookie2.split(";")[0];
+    } catch (e) {
+      logAxiosError('session-form', e);
+    }
+
+    // 3) Basic Auth
+    try {
+      const basic = Buffer.from(`${user}:${pass}`).toString("base64");
+      const resp3 = await axios.get(url, {
+        headers: { Authorization: `Basic ${basic}` },
+        withCredentials: true,
+        ...httpsCfg,
+      });
+      const cookie3 = resp3.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
+      if (!cookie3) throw new Error("Sessão sem JSESSIONID (basic)");
+      return cookie3.split(";")[0];
+    } catch (e) {
+      logAxiosError('session-basic', e);
+    }
   }
 
-  // 2) x-www-form-urlencoded
-  try {
-    const form = new URLSearchParams({ email: user, password: pass });
-    const resp2 = await axios.post(url, form.toString(), {
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      withCredentials: true,
-      ...httpsCfg,
-    });
-    const cookie2 = resp2.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
-    if (!cookie2) throw new Error("Sessão sem JSESSIONID (form)");
-    return cookie2.split(";")[0];
-  } catch (e) {
-    logAxiosError('session-form', e);
+  if (token) {
+    try {
+      const resp = await axios.get(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        withCredentials: true,
+        ...httpsCfg,
+      });
+      const cookie = resp.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
+      if (!cookie) throw new Error("Sessão sem JSESSIONID (token)");
+      return cookie.split(";")[0];
+    } catch (e) {
+      logAxiosError('session-token', e);
+    }
   }
 
-  // 3) Basic Auth
-  try {
-    const basic = Buffer.from(`${user}:${pass}`).toString("base64");
-    const resp3 = await axios.get(url, {
-      headers: { Authorization: `Basic ${basic}` },
-      withCredentials: true,
-      ...httpsCfg,
-    });
-    const cookie3 = resp3.headers["set-cookie"]?.find(c => c.startsWith("JSESSIONID="));
-    if (!cookie3) throw new Error("Sessão sem JSESSIONID (basic)");
-    return cookie3.split(";")[0];
-  } catch (e) {
-    logAxiosError('session-basic', e);
-    throw e;
-  }
+  throw new Error("Não foi possível obter cookie de sessão do Traccar");
 }
 
 
 function openWs(cookie) {
-  const wsUrl = buildWsUrl(baseURL);
+  if (!httpBaseURL) {
+    throw new Error("TRACCAR_BASE_URL inválido; não é possível montar URL do WebSocket");
+  }
+  const wsUrl = buildTraccarWsUrl(httpBaseURL);
   const wsOpts = { headers: { Cookie: cookie } };
   if (allowSelfSigned) wsOpts.rejectUnauthorized = false;
 
@@ -139,9 +160,21 @@ function scheduleReconnect() {
 }
 
 export function startRealtimeBridge() {
-  if (!user || !pass) {
-    console.warn("TRACCAR_USER/TRACCAR_PASS não definidos; WS não será iniciado (REST continua funcionando).");
+  if (!baseURL) {
+    console.warn("TRACCAR_BASE_URL não definido; WS não será iniciado.");
     return;
   }
+
+  if (!httpBaseURL || !apiBaseURL) {
+    const extra = baseUrlError ? ` (${baseUrlError})` : "";
+    console.warn(`TRACCAR_BASE_URL inválido; informe algo como http://host:8082 ou http://host:8082/api.${extra}`);
+    return;
+  }
+
+  if (!((user && pass) || token)) {
+    console.warn("Credenciais do Traccar ausentes; defina TRACCAR_USER/TRACCAR_PASS ou TRACCAR_TOKEN para habilitar o WS.");
+    return;
+  }
+
   connect();
 }

--- a/backend/src/services/traccarClient.js
+++ b/backend/src/services/traccarClient.js
@@ -1,12 +1,24 @@
-﻿import axios from "axios";
+import axios from "axios";
 // import https from "https"; // se usar HTTPS self-signed, descomente o Agent abaixo
+
+import { parseTraccarBaseUrl } from "../utils/traccarUrls.js";
 
 const baseURL = process.env.TRACCAR_BASE_URL;
 const token   = process.env.TRACCAR_TOKEN;
 
+const { httpBaseURL, error: baseUrlError } = parseTraccarBaseUrl(baseURL);
+const axiosBaseURL = httpBaseURL ?? baseURL;
+
+if (!axiosBaseURL && baseUrlError) {
+  console.warn(`TRACCAR_BASE_URL inválido; informe algo como http://host:8082 ou http://host:8082/api. (${baseUrlError})`);
+}
+
+const headers = {};
+if (token) headers.Authorization = `Bearer ${token}`;
+
 export const traccar = axios.create({
-  baseURL,
-  headers: { Authorization: 'Bearer ' + token },
+  baseURL: axiosBaseURL,
+  headers,
   timeout: 10000,
   // httpsAgent: new https.Agent({ rejectUnauthorized: false }),
 });

--- a/backend/src/users/authMiddleware.js
+++ b/backend/src/users/authMiddleware.js
@@ -1,0 +1,22 @@
+import { getSession, revokeSession } from "./sessionStore.js";
+import { getUserById, sanitizeUser } from "./userStore.js";
+
+export function requireAuth(req, res, next) {
+  const header = req.headers.authorization || "";
+  const [scheme, token] = header.split(" ");
+  if (scheme !== "Bearer" || !token) {
+    return res.status(401).json({ error: "Token de autenticação ausente" });
+  }
+  const session = getSession(token);
+  if (!session) {
+    return res.status(401).json({ error: "Sessão inválida ou expirada" });
+  }
+  const user = getUserById(session.userId);
+  if (!user) {
+    revokeSession(token);
+    return res.status(401).json({ error: "Usuário não encontrado" });
+  }
+  req.authToken = token;
+  req.user = sanitizeUser(user);
+  next();
+}

--- a/backend/src/users/crypto.js
+++ b/backend/src/users/crypto.js
@@ -1,0 +1,23 @@
+import { randomBytes, scryptSync, timingSafeEqual } from "crypto";
+
+const KEYLEN = 64;
+
+export function hashPassword(password) {
+  if (!password || typeof password !== "string") {
+    throw new Error("Senha inválida");
+  }
+  const salt = randomBytes(16).toString("hex");
+  const hash = scryptSync(password, salt, KEYLEN).toString("hex");
+  return { salt, hash };
+}
+
+export function verifyPassword(password, hash, salt) {
+  if (!password || !hash || !salt) return false;
+  try {
+    const derived = scryptSync(password, salt, KEYLEN);
+    const expected = Buffer.from(hash, "hex");
+    return derived.length === expected.length && timingSafeEqual(derived, expected);
+  } catch {
+    return false;
+  }
+}

--- a/backend/src/users/sessionStore.js
+++ b/backend/src/users/sessionStore.js
@@ -1,0 +1,33 @@
+import { randomUUID } from "crypto";
+
+const DEFAULT_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+const sessions = new Map();
+
+export function createSession(userId, ttlMs = DEFAULT_TTL_MS) {
+  const token = randomUUID();
+  const expiresAt = Date.now() + ttlMs;
+  sessions.set(token, { userId, expiresAt });
+  return { token, expiresAt };
+}
+
+export function getSession(token) {
+  if (!token) return null;
+  const session = sessions.get(token);
+  if (!session) return null;
+  if (session.expiresAt < Date.now()) {
+    sessions.delete(token);
+    return null;
+  }
+  return session;
+}
+
+export function revokeSession(token) {
+  if (token) sessions.delete(token);
+}
+
+export function purgeExpiredSessions() {
+  const now = Date.now();
+  for (const [token, session] of sessions.entries()) {
+    if (session.expiresAt < now) sessions.delete(token);
+  }
+}

--- a/backend/src/users/userStore.js
+++ b/backend/src/users/userStore.js
@@ -1,0 +1,254 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { hashPassword } from "./crypto.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const dataDir = path.resolve(__dirname, "../../data");
+const dataFile = path.join(dataDir, "users.json");
+
+export const Roles = Object.freeze({
+  ADMIN: "admin",
+  MASTER: "master",
+  CHILD: "child",
+});
+
+const DEFAULT_MASTER_POLICIES = {
+  maxChildUsers: 15,
+  childDeviceLimit: 50,
+  childAllowedViews: ["dashboard", "map", "vehicles", "alerts", "trips"],
+  childCanExportReports: false,
+  childCanManageDrivers: false,
+};
+
+const DEFAULT_CHILD_RESTRICTIONS = {
+  allowedViews: ["dashboard", "map", "alerts"],
+  deviceLimit: 25,
+  canExportReports: false,
+  canManageDrivers: false,
+  canAcknowledgeAlerts: true,
+};
+
+let cache = null;
+
+function ensureDataFile() {
+  if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+  if (!fs.existsSync(dataFile)) {
+    const { hash, salt } = hashPassword(
+      process.env.ADMIN_DEFAULT_PASSWORD || "admin123"
+    );
+    const adminUser = {
+      id: "admin",
+      email: process.env.ADMIN_DEFAULT_EMAIL || "admin@linka.local",
+      name: "Administrador",
+      role: Roles.ADMIN,
+      passwordHash: hash,
+      passwordSalt: salt,
+      restrictions: {
+        masterPolicies: {
+          ...DEFAULT_MASTER_POLICIES,
+        },
+      },
+      createdAt: new Date().toISOString(),
+    };
+    fs.writeFileSync(dataFile, JSON.stringify([adminUser], null, 2));
+  }
+}
+
+function readUsers() {
+  if (cache) return cache;
+  ensureDataFile();
+  const raw = fs.readFileSync(dataFile, "utf-8");
+  cache = JSON.parse(raw);
+  return cache;
+}
+
+function writeUsers(users) {
+  cache = users;
+  fs.writeFileSync(dataFile, JSON.stringify(users, null, 2));
+}
+
+export function initializeUserStore() {
+  ensureDataFile();
+  cache = null;
+  readUsers();
+}
+
+export function getAllUsers() {
+  return readUsers();
+}
+
+export function getUserByEmail(email) {
+  if (!email) return undefined;
+  return readUsers().find((user) => user.email.toLowerCase() === email.toLowerCase());
+}
+
+export function getUserById(id) {
+  if (!id) return undefined;
+  return readUsers().find((user) => user.id === id);
+}
+
+function nextUserId(prefix) {
+  const users = readUsers();
+  let counter = 1;
+  const base = prefix || "user";
+  let candidate = `${base}-${counter}`;
+  const ids = new Set(users.map((u) => u.id));
+  while (ids.has(candidate)) {
+    counter += 1;
+    candidate = `${base}-${counter}`;
+  }
+  return candidate;
+}
+
+export function sanitizeUser(user) {
+  if (!user) return undefined;
+  const { passwordHash, passwordSalt, ...rest } = user;
+  return rest;
+}
+
+function countChildren(masterId) {
+  return readUsers().filter((u) => u.parentId === masterId).length;
+}
+
+function sanitizeChildRestrictions(input = {}, policies = DEFAULT_MASTER_POLICIES) {
+  const allowedUniverse = policies.childAllowedViews || DEFAULT_MASTER_POLICIES.childAllowedViews;
+  const allowedViews = Array.isArray(input.allowedViews)
+    ? input.allowedViews.filter((view) => allowedUniverse.includes(view))
+    : DEFAULT_CHILD_RESTRICTIONS.allowedViews.filter((view) => allowedUniverse.includes(view));
+  const deviceLimitRaw = Number(input.deviceLimit ?? DEFAULT_CHILD_RESTRICTIONS.deviceLimit);
+  const deviceLimit = Math.max(1, Math.min(deviceLimitRaw, policies.childDeviceLimit || DEFAULT_MASTER_POLICIES.childDeviceLimit));
+
+  return {
+    allowedViews: allowedViews.length ? [...new Set(allowedViews)] : [...allowedUniverse],
+    deviceLimit,
+    canExportReports: Boolean(input.canExportReports && (policies.childCanExportReports ?? false)),
+    canManageDrivers: Boolean(input.canManageDrivers && (policies.childCanManageDrivers ?? false)),
+    canAcknowledgeAlerts:
+      input.canAcknowledgeAlerts == null
+        ? DEFAULT_CHILD_RESTRICTIONS.canAcknowledgeAlerts
+        : Boolean(input.canAcknowledgeAlerts),
+  };
+}
+
+function sanitizeMasterPolicies(input = {}) {
+  const maxChildUsers = Math.max(1, Math.min(Number(input.maxChildUsers ?? DEFAULT_MASTER_POLICIES.maxChildUsers), 200));
+  const childDeviceLimit = Math.max(1, Math.min(Number(input.childDeviceLimit ?? DEFAULT_MASTER_POLICIES.childDeviceLimit), 500));
+  const allowedUniverse = DEFAULT_MASTER_POLICIES.childAllowedViews;
+  const allowedViews = Array.isArray(input.childAllowedViews)
+    ? input.childAllowedViews.filter((view) => allowedUniverse.includes(view))
+    : allowedUniverse;
+
+  return {
+    maxChildUsers,
+    childDeviceLimit,
+    childAllowedViews: allowedViews.length ? [...new Set(allowedViews)] : allowedUniverse,
+    childCanExportReports: Boolean(input.childCanExportReports ?? DEFAULT_MASTER_POLICIES.childCanExportReports),
+    childCanManageDrivers: Boolean(input.childCanManageDrivers ?? DEFAULT_MASTER_POLICIES.childCanManageDrivers),
+  };
+}
+
+export function listUsersFor(actor) {
+  const users = readUsers();
+  if (!actor) return [];
+  if (actor.role === Roles.ADMIN) {
+    return users.map(sanitizeUser);
+  }
+  if (actor.role === Roles.MASTER) {
+    return users
+      .filter((user) => user.id === actor.id || user.parentId === actor.id)
+      .map(sanitizeUser);
+  }
+  return users.filter((user) => user.id === actor.id).map(sanitizeUser);
+}
+
+export function createUser(actor, payload = {}) {
+  if (!actor) {
+    throw new Error("Usuário autenticado obrigatório");
+  }
+
+  const { name, email, password, role, restrictions = {}, parentId } = payload;
+
+  if (!name?.trim()) throw new Error("Nome é obrigatório");
+  if (!email?.trim()) throw new Error("E-mail é obrigatório");
+  if (!password || password.length < 6) throw new Error("Senha deve ter ao menos 6 caracteres");
+  if (!role || !Object.values(Roles).includes(role)) throw new Error("Perfil inválido");
+
+  if (getUserByEmail(email)) {
+    throw new Error("E-mail já cadastrado");
+  }
+
+  const allUsers = readUsers();
+
+  if (role === Roles.ADMIN) {
+    throw new Error("Não é permitido criar novos administradores");
+  }
+
+  const { hash, salt } = hashPassword(password);
+
+  if (role === Roles.MASTER) {
+    if (actor.role !== Roles.ADMIN) {
+      throw new Error("Somente o administrador pode criar usuários mestre");
+    }
+    const masterPolicies = sanitizeMasterPolicies(restrictions.masterPolicies || restrictions);
+    const user = {
+      id: nextUserId("master"),
+      name: name.trim(),
+      email: email.trim().toLowerCase(),
+      role: Roles.MASTER,
+      passwordHash: hash,
+      passwordSalt: salt,
+      restrictions: {
+        masterPolicies,
+      },
+      createdAt: new Date().toISOString(),
+      createdBy: actor.id,
+    };
+    const updated = [...allUsers, user];
+    writeUsers(updated);
+    return sanitizeUser(user);
+  }
+
+  if (role === Roles.CHILD) {
+    if (![Roles.ADMIN, Roles.MASTER].includes(actor.role)) {
+      throw new Error("Permissão insuficiente para criar usuários filhos");
+    }
+
+    let owner = actor;
+    if (actor.role === Roles.ADMIN) {
+      if (!parentId) throw new Error("Informe o usuário mestre responsável");
+      const master = getUserById(parentId);
+      if (!master || master.role !== Roles.MASTER) {
+        throw new Error("Usuário mestre inválido");
+      }
+      owner = master;
+    }
+
+    const policies = owner.restrictions?.masterPolicies || DEFAULT_MASTER_POLICIES;
+    const currentChildren = countChildren(owner.id);
+    if (currentChildren >= policies.maxChildUsers) {
+      throw new Error("Limite de usuários filhos para este mestre foi atingido");
+    }
+
+    const childRestrictions = sanitizeChildRestrictions(restrictions, policies);
+
+    const user = {
+      id: nextUserId("child"),
+      name: name.trim(),
+      email: email.trim().toLowerCase(),
+      role: Roles.CHILD,
+      passwordHash: hash,
+      passwordSalt: salt,
+      restrictions: childRestrictions,
+      parentId: owner.id,
+      createdAt: new Date().toISOString(),
+      createdBy: actor.id,
+    };
+    const updated = [...allUsers, user];
+    writeUsers(updated);
+    return sanitizeUser(user);
+  }
+
+  throw new Error("Perfil inválido para criação");
+}

--- a/backend/src/utils/traccarUrls.js
+++ b/backend/src/utils/traccarUrls.js
@@ -1,0 +1,50 @@
+export function parseTraccarBaseUrl(rawBaseURL) {
+  if (!rawBaseURL) {
+    return {
+      rawBaseURL,
+      trimmedBaseURL: undefined,
+      httpBaseURL: undefined,
+      apiBaseURL: undefined,
+      error: "TRACCAR_BASE_URL não definido",
+    };
+  }
+
+  const trimmedBaseURL = rawBaseURL.replace(/\/+$/, "");
+  const maybeHttpBase = trimmedBaseURL.endsWith("/api")
+    ? trimmedBaseURL.slice(0, -4)
+    : trimmedBaseURL;
+
+  try {
+    const parsed = new URL(maybeHttpBase);
+    if (!/^https?:$/.test(parsed.protocol)) {
+      throw new Error("Protocol must be http or https");
+    }
+
+    const normalizedPath = parsed.pathname.replace(/\/+$/, "");
+    const httpBaseURL = `${parsed.origin}${normalizedPath === "/" ? "" : normalizedPath}`;
+    const apiBaseURL = `${httpBaseURL}/api`;
+
+    return {
+      rawBaseURL,
+      trimmedBaseURL,
+      httpBaseURL,
+      apiBaseURL,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      rawBaseURL,
+      trimmedBaseURL,
+      httpBaseURL: undefined,
+      apiBaseURL: undefined,
+      error: err?.message || "URL inválida",
+    };
+  }
+}
+
+export function buildTraccarWsUrl(httpBaseURL) {
+  const trimmed = httpBaseURL.replace(/\/+$/, "");
+  const proto = trimmed.startsWith("https") ? "wss" : "ws";
+  const host = trimmed.replace(/^https?:\/\//, "");
+  return `${proto}://${host}/api/socket`;
+}

--- a/src/components/Admin/AdminView.tsx
+++ b/src/components/Admin/AdminView.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
-import { 
-  Building, 
-  Truck, 
-  Smartphone, 
-  Users, 
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Building,
+  Truck,
+  Smartphone,
+  Users,
   Shield, 
   BarChart3,
   Settings as SettingsIcon
@@ -16,23 +16,55 @@ import { RolesManagement } from './RolesManagement';
 import { AdminReports } from './AdminReports';
 import { EquipmentRegistration } from '../Equipment/EquipmentRegistration';
 import { AdminSettings } from './AdminSettings';
+import { UserHierarchyManager } from './UserHierarchyManager';
+import { AuthUser } from '../../context/AuthContext';
 
-export const AdminView: React.FC = () => {
-  const [activeTab, setActiveTab] = useState('clients');
+interface AdminViewProps {
+  currentUser: AuthUser;
+}
 
-  const tabs = [
-    { id: 'clients', label: 'Clientes', icon: Building },
-    { id: 'equipment', label: 'Equipamentos', icon: Smartphone },
-    { id: 'vehicles', label: 'Veículos', icon: Truck },
-    { id: 'devices', label: 'Dispositivos', icon: Smartphone },
-    { id: 'drivers', label: 'Motoristas', icon: Users },
-    { id: 'roles', label: 'Perfis & Permissões', icon: Shield },
-    { id: 'reports', label: 'Relatórios', icon: BarChart3 },
-    { id: 'settings', label: 'Configurações', icon: SettingsIcon },
-  ];
+export const AdminView: React.FC<AdminViewProps> = ({ currentUser }) => {
+  const isAdmin = currentUser.role === 'admin';
+  const isMaster = currentUser.role === 'master';
+
+  const tabs = useMemo(() => {
+    const base = [{ id: 'users', label: 'Usuários', icon: Users }];
+    if (isAdmin) {
+      return [
+        ...base,
+        { id: 'clients', label: 'Clientes', icon: Building },
+        { id: 'equipment', label: 'Equipamentos', icon: Smartphone },
+        { id: 'vehicles', label: 'Veículos', icon: Truck },
+        { id: 'devices', label: 'Dispositivos', icon: Smartphone },
+        { id: 'drivers', label: 'Motoristas', icon: Users },
+        { id: 'roles', label: 'Perfis & Permissões', icon: Shield },
+        { id: 'reports', label: 'Relatórios', icon: BarChart3 },
+        { id: 'settings', label: 'Configurações', icon: SettingsIcon },
+      ];
+    }
+    if (isMaster) {
+      return [
+        ...base,
+        { id: 'drivers', label: 'Motoristas', icon: Users },
+        { id: 'reports', label: 'Relatórios', icon: BarChart3 },
+        { id: 'settings', label: 'Configurações', icon: SettingsIcon },
+      ];
+    }
+    return base;
+  }, [isAdmin, isMaster]);
+
+  const [activeTab, setActiveTab] = useState(tabs[0]?.id ?? 'users');
+
+  useEffect(() => {
+    if (!tabs.some((tab) => tab.id === activeTab)) {
+      setActiveTab(tabs[0]?.id ?? 'users');
+    }
+  }, [tabs, activeTab]);
 
   const renderTabContent = () => {
     switch (activeTab) {
+      case 'users':
+        return <UserHierarchyManager currentUser={currentUser} isAdmin={isAdmin} />;
       case 'clients':
         return <ClientsManagement />;
       case 'equipment':

--- a/src/components/Admin/UserHierarchyManager.tsx
+++ b/src/components/Admin/UserHierarchyManager.tsx
@@ -1,0 +1,670 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Plus, Loader2, Users as UsersIcon, ShieldCheck, AlertTriangle } from 'lucide-react';
+import { useAuth, AuthUser } from '../../context/AuthContext';
+
+const CHILD_VIEW_OPTIONS = [
+  { id: 'dashboard', label: 'Dashboard' },
+  { id: 'map', label: 'Mapa da Frota' },
+  { id: 'vehicles', label: 'Veículos' },
+  { id: 'alerts', label: 'Alertas' },
+  { id: 'trips', label: 'Viagens' },
+];
+
+interface UserHierarchyManagerProps {
+  currentUser: AuthUser;
+  isAdmin: boolean;
+}
+
+type Feedback = { type: 'success' | 'error'; message: string } | null;
+
+type MasterFormState = {
+  name: string;
+  email: string;
+  password: string;
+  maxChildUsers: number;
+  childDeviceLimit: number;
+  childAllowedViews: string[];
+  childCanExportReports: boolean;
+  childCanManageDrivers: boolean;
+};
+
+type ChildFormState = {
+  name: string;
+  email: string;
+  password: string;
+  parentId: string;
+  allowedViews: string[];
+  deviceLimit: number;
+  canExportReports: boolean;
+  canManageDrivers: boolean;
+  canAcknowledgeAlerts: boolean;
+};
+
+function toPositiveInteger(value: number, fallback: number) {
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+export const UserHierarchyManager: React.FC<UserHierarchyManagerProps> = ({ currentUser, isAdmin }) => {
+  const { apiFetch, refreshProfile } = useAuth();
+  const [users, setUsers] = useState<AuthUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const [creatingMaster, setCreatingMaster] = useState(false);
+  const [creatingChild, setCreatingChild] = useState(false);
+
+  const masterInitialState = useMemo<MasterFormState>(() => ({
+    name: '',
+    email: '',
+    password: '',
+    maxChildUsers: 10,
+    childDeviceLimit: 50,
+    childAllowedViews: CHILD_VIEW_OPTIONS.map((option) => option.id),
+    childCanExportReports: false,
+    childCanManageDrivers: false,
+  }), []);
+
+  const [masterForm, setMasterForm] = useState<MasterFormState>(masterInitialState);
+  const [childForm, setChildForm] = useState<ChildFormState>({
+    name: '',
+    email: '',
+    password: '',
+    parentId: isAdmin ? '' : currentUser.id,
+    allowedViews: ['dashboard', 'map', 'alerts'],
+    deviceLimit: 10,
+    canExportReports: false,
+    canManageDrivers: false,
+    canAcknowledgeAlerts: true,
+  });
+
+  const fetchUsers = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await apiFetch<{ users: AuthUser[] }>('/users');
+      setUsers(data.users || []);
+      setFeedback(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Falha ao carregar usuários';
+      setFeedback({ type: 'error', message });
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch]);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      setChildForm((prev) => ({ ...prev, parentId: currentUser.id }));
+    }
+  }, [isAdmin, currentUser.id]);
+
+  const masters = useMemo(() => {
+    const list = users.filter((user) => user.role === 'master');
+    if (isAdmin) return list;
+    return list.filter((user) => user.id === currentUser.id);
+  }, [users, isAdmin, currentUser.id]);
+
+  const masterMap = useMemo(() => new Map(masters.map((master) => [master.id, master])), [masters]);
+
+  useEffect(() => {
+    if (isAdmin && !childForm.parentId && masters.length) {
+      setChildForm((prev) => ({ ...prev, parentId: masters[0].id }));
+    }
+  }, [isAdmin, masters, childForm.parentId]);
+
+  const childOwner = useMemo(() => {
+    if (isAdmin) {
+      return masterMap.get(childForm.parentId) || masters[0];
+    }
+    return masterMap.get(currentUser.id) || masters[0];
+  }, [isAdmin, childForm.parentId, masterMap, masters, currentUser.id]);
+
+  const childPolicies = childOwner?.restrictions?.masterPolicies;
+  const allowedChildViews = childPolicies?.childAllowedViews ?? CHILD_VIEW_OPTIONS.map((option) => option.id);
+  const childDeviceLimit = childPolicies?.childDeviceLimit ?? 50;
+  const canGrantReports = childPolicies?.childCanExportReports ?? false;
+  const canGrantDrivers = childPolicies?.childCanManageDrivers ?? false;
+  const childLimit = childPolicies?.maxChildUsers ?? null;
+
+  const childUsers = useMemo(() => {
+    const list = users.filter((user) => user.role === 'child');
+    if (isAdmin) return list;
+    return list.filter((user) => user.parentId === currentUser.id);
+  }, [users, isAdmin, currentUser.id]);
+
+  const childUsersByMaster = useMemo(() => {
+    const map = new Map<string, AuthUser[]>();
+    for (const child of childUsers) {
+      const key = child.parentId || 'unknown';
+      if (!map.has(key)) {
+        map.set(key, []);
+      }
+      map.get(key)!.push(child);
+    }
+    return map;
+  }, [childUsers]);
+
+  const remainingSlots = useMemo(() => {
+    if (!childOwner || childLimit == null) return null;
+    const used = childUsersByMaster.get(childOwner.id)?.length ?? 0;
+    return childLimit - used;
+  }, [childOwner, childLimit, childUsersByMaster]);
+
+  const resetMasterForm = () => setMasterForm(masterInitialState);
+  const resetChildForm = () => setChildForm({
+    name: '',
+    email: '',
+    password: '',
+    parentId: isAdmin ? (masters[0]?.id || '') : currentUser.id,
+    allowedViews: allowedChildViews.includes('dashboard') ? ['dashboard'] : [allowedChildViews[0] ?? 'dashboard'],
+    deviceLimit: Math.min(10, childDeviceLimit),
+    canExportReports: false,
+    canManageDrivers: false,
+    canAcknowledgeAlerts: true,
+  });
+
+  const handleCreateMaster = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!masterForm.name.trim() || !masterForm.email.trim() || !masterForm.password.trim()) {
+      setFeedback({ type: 'error', message: 'Preencha nome, e-mail e senha do usuário mestre.' });
+      return;
+    }
+    setCreatingMaster(true);
+    try {
+      await apiFetch('/users', {
+        method: 'POST',
+        body: JSON.stringify({
+          name: masterForm.name.trim(),
+          email: masterForm.email.trim().toLowerCase(),
+          password: masterForm.password,
+          role: 'master',
+          restrictions: {
+            masterPolicies: {
+              maxChildUsers: toPositiveInteger(masterForm.maxChildUsers, 10),
+              childDeviceLimit: toPositiveInteger(masterForm.childDeviceLimit, 50),
+              childAllowedViews: masterForm.childAllowedViews.filter((view) => CHILD_VIEW_OPTIONS.some((opt) => opt.id === view)),
+              childCanExportReports: masterForm.childCanExportReports,
+              childCanManageDrivers: masterForm.childCanManageDrivers,
+            },
+          },
+        }),
+      });
+      setFeedback({ type: 'success', message: 'Usuário mestre criado com sucesso.' });
+      resetMasterForm();
+      await fetchUsers();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Não foi possível criar o usuário mestre';
+      setFeedback({ type: 'error', message });
+    } finally {
+      setCreatingMaster(false);
+    }
+  };
+
+  const handleCreateChild = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!childForm.name.trim() || !childForm.email.trim() || !childForm.password.trim()) {
+      setFeedback({ type: 'error', message: 'Preencha nome, e-mail e senha do usuário filho.' });
+      return;
+    }
+    if (isAdmin && !childForm.parentId) {
+      setFeedback({ type: 'error', message: 'Selecione um usuário mestre responsável.' });
+      return;
+    }
+    setCreatingChild(true);
+    try {
+      const allowedViews = childForm.allowedViews.filter((view) => allowedChildViews.includes(view));
+      const payload = {
+        name: childForm.name.trim(),
+        email: childForm.email.trim().toLowerCase(),
+        password: childForm.password,
+        role: 'child',
+        parentId: isAdmin ? childForm.parentId : currentUser.id,
+        restrictions: {
+          allowedViews: allowedViews.length ? allowedViews : [allowedChildViews[0]],
+          deviceLimit: Math.min(toPositiveInteger(childForm.deviceLimit, 10), childDeviceLimit),
+          canExportReports: canGrantReports ? childForm.canExportReports : false,
+          canManageDrivers: canGrantDrivers ? childForm.canManageDrivers : false,
+          canAcknowledgeAlerts: childForm.canAcknowledgeAlerts,
+        },
+      };
+      await apiFetch('/users', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+      setFeedback({ type: 'success', message: 'Usuário filho criado com sucesso.' });
+      resetChildForm();
+      await fetchUsers();
+      if (!isAdmin) {
+        await refreshProfile();
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Não foi possível criar o usuário filho';
+      setFeedback({ type: 'error', message });
+    } finally {
+      setCreatingChild(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900">Gestão de Usuários</h2>
+          <p className="text-gray-600">Controle hierárquico entre administrador, mestres e usuários filhos</p>
+        </div>
+        <div className="flex items-center gap-2 text-sm text-gray-500">
+          <ShieldCheck className="w-4 h-4 text-blue-500" />
+          <span>{isAdmin ? 'Administrador com acesso total' : 'Acesso mestre para criar usuários filhos'}</span>
+        </div>
+      </div>
+
+      {feedback && (
+        <div
+          className={`border rounded-xl px-4 py-3 text-sm ${
+            feedback.type === 'success'
+              ? 'bg-green-50 border-green-200 text-green-700'
+              : 'bg-red-50 border-red-200 text-red-700'
+          }`}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12 text-gray-500">
+          <Loader2 className="w-6 h-6 animate-spin mr-2" /> Carregando usuários...
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+          <div className="xl:col-span-2 space-y-6">
+            <section className="bg-white border border-gray-200 rounded-xl p-6">
+              <div className="flex items-center justify-between mb-4">
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+                    <UsersIcon className="w-5 h-5 text-blue-600" /> Usuários Mestre
+                  </h3>
+                  <p className="text-sm text-gray-500">Responsáveis por cadastrar e gerenciar usuários filhos</p>
+                </div>
+                <span className="text-sm text-gray-500">{masters.length} mestre(s) cadastrados</span>
+              </div>
+
+              <div className="space-y-4">
+                {masters.map((master) => {
+                  const policies = master.restrictions?.masterPolicies;
+                  const children = childUsersByMaster.get(master.id) || [];
+                  return (
+                    <div key={master.id} className="border border-gray-200 rounded-lg p-4">
+                      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                        <div>
+                          <h4 className="text-base font-semibold text-gray-900">{master.name}</h4>
+                          <p className="text-sm text-gray-500">{master.email}</p>
+                          <p className="text-xs text-gray-400 mt-1">ID: {master.id}</p>
+                        </div>
+                        {policies && (
+                          <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 text-xs text-blue-700 space-y-1">
+                            <p>
+                              <strong>Limite de filhos:</strong> {policies.maxChildUsers}
+                            </p>
+                            <p>
+                              <strong>Dispositivos por filho:</strong> até {policies.childDeviceLimit}
+                            </p>
+                            <p>
+                              <strong>Funcionalidades:</strong>{' '}
+                              {[
+                                policies.childCanExportReports && 'relatórios',
+                                policies.childCanManageDrivers && 'gestão de motoristas',
+                              ]
+                                .filter(Boolean)
+                                .join(', ') || 'acesso básico'}
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                      <div className="mt-4">
+                        <p className="text-sm text-gray-600 mb-2">Usuários filhos ({children.length})</p>
+                        <div className="space-y-2">
+                          {children.length === 0 ? (
+                            <p className="text-sm text-gray-400">Nenhum usuário filho cadastrado.</p>
+                          ) : (
+                            children.map((child) => (
+                              <div key={child.id} className="flex items-center justify-between text-sm border border-gray-100 rounded-lg px-3 py-2">
+                                <div>
+                                  <p className="font-medium text-gray-800">{child.name}</p>
+                                  <p className="text-xs text-gray-500">{child.email}</p>
+                                </div>
+                                <div className="text-xs text-gray-500 text-right">
+                                  <p>Acessos: {(child.restrictions?.allowedViews || []).join(', ') || '---'}</p>
+                                  <p>Limite dispositivos: {child.restrictions?.deviceLimit ?? '---'}</p>
+                                </div>
+                              </div>
+                            ))
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            <section className="bg-white border border-gray-200 rounded-xl p-6">
+              <div className="flex items-center gap-2 mb-4">
+                <AlertTriangle className="w-5 h-5 text-amber-500" />
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900">Regras de acesso para usuários filhos</h3>
+                  <p className="text-sm text-gray-500">
+                    Defina quais módulos e permissões cada usuário filho pode acessar. As restrições respeitam o limite definido pelo mestre responsável.
+                  </p>
+                </div>
+              </div>
+
+              <form className="space-y-5" onSubmit={handleCreateChild}>
+                {isAdmin && (
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Usuário mestre responsável</label>
+                    <select
+                      value={childForm.parentId}
+                      onChange={(event) => setChildForm((prev) => ({ ...prev, parentId: event.target.value }))}
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500"
+                    >
+                      <option value="">Selecione um mestre</option>
+                      {masters.map((master) => (
+                        <option key={master.id} value={master.id}>
+                          {master.name} ({master.email})
+                        </option>
+                      ))}
+                    </select>
+                    {remainingSlots != null && (
+                      <p className="text-xs text-gray-500 mt-1">
+                        {remainingSlots > 0
+                          ? `${remainingSlots} vaga(s) disponível(is) para este mestre`
+                          : 'Limite de usuários filhos atingido para este mestre'}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Nome</label>
+                    <input
+                      type="text"
+                      value={childForm.name}
+                      onChange={(event) => setChildForm((prev) => ({ ...prev, name: event.target.value }))}
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500"
+                      placeholder="Nome completo"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">E-mail</label>
+                    <input
+                      type="email"
+                      value={childForm.email}
+                      onChange={(event) => setChildForm((prev) => ({ ...prev, email: event.target.value }))}
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500"
+                      placeholder="usuario@empresa.com"
+                    />
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Senha</label>
+                  <input
+                    type="password"
+                    value={childForm.password}
+                    onChange={(event) => setChildForm((prev) => ({ ...prev, password: event.target.value }))}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500"
+                    placeholder="Mínimo de 6 caracteres"
+                  />
+                </div>
+
+                <div>
+                  <span className="block text-sm font-medium text-gray-700 mb-2">Módulos permitidos</span>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    {CHILD_VIEW_OPTIONS.map((option) => {
+                      const disabled = !allowedChildViews.includes(option.id);
+                      const checked = childForm.allowedViews.includes(option.id) && !disabled;
+                      return (
+                        <label
+                          key={option.id}
+                          className={`flex items-center gap-2 border rounded-lg px-3 py-2 text-sm ${
+                            disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:border-blue-400'
+                          }`}
+                        >
+                          <input
+                            type="checkbox"
+                            disabled={disabled}
+                            checked={checked}
+                            onChange={() => {
+                              setChildForm((prev) => {
+                                const alreadySelected = prev.allowedViews.includes(option.id);
+                                if (alreadySelected) {
+                                  return { ...prev, allowedViews: prev.allowedViews.filter((view) => view !== option.id) };
+                                }
+                                return { ...prev, allowedViews: [...prev.allowedViews, option.id] };
+                              });
+                            }}
+                          />
+                          <span>{option.label}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Limite de dispositivos</label>
+                    <input
+                      type="number"
+                      min={1}
+                      max={childDeviceLimit}
+                      value={childForm.deviceLimit}
+                      onChange={(event) => setChildForm((prev) => ({ ...prev, deviceLimit: Number(event.target.value) }))}
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500"
+                    />
+                    <p className="text-xs text-gray-500 mt-1">Máximo permitido: {childDeviceLimit} dispositivos</p>
+                  </div>
+                  <div className="space-y-2">
+                    <label className="block text-sm font-medium text-gray-700">Permissões extras</label>
+                    <label className={`flex items-center gap-2 text-sm ${canGrantReports ? '' : 'opacity-50'}`}>
+                      <input
+                        type="checkbox"
+                        disabled={!canGrantReports}
+                        checked={canGrantReports && childForm.canExportReports}
+                        onChange={(event) => setChildForm((prev) => ({ ...prev, canExportReports: event.target.checked }))}
+                      />
+                      Pode exportar relatórios
+                    </label>
+                    <label className={`flex items-center gap-2 text-sm ${canGrantDrivers ? '' : 'opacity-50'}`}>
+                      <input
+                        type="checkbox"
+                        disabled={!canGrantDrivers}
+                        checked={canGrantDrivers && childForm.canManageDrivers}
+                        onChange={(event) => setChildForm((prev) => ({ ...prev, canManageDrivers: event.target.checked }))}
+                      />
+                      Pode gerenciar motoristas
+                    </label>
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={childForm.canAcknowledgeAlerts}
+                        onChange={(event) => setChildForm((prev) => ({ ...prev, canAcknowledgeAlerts: event.target.checked }))}
+                      />
+                      Pode reconhecer alertas
+                    </label>
+                  </div>
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={creatingChild || (remainingSlots != null && remainingSlots <= 0)}
+                  className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                    creatingChild || (remainingSlots != null && remainingSlots <= 0)
+                      ? 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                      : 'bg-blue-600 text-white hover:bg-blue-700'
+                  }`}
+                >
+                  {creatingChild ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin" /> Salvando...
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="w-4 h-4" /> Criar usuário filho
+                    </>
+                  )}
+                </button>
+              </form>
+            </section>
+          </div>
+
+          <div className="space-y-6">
+            {isAdmin && (
+              <section className="bg-white border border-gray-200 rounded-xl p-6">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">Novo usuário mestre</h3>
+                <form className="space-y-4" onSubmit={handleCreateMaster}>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Nome</label>
+                    <input
+                      type="text"
+                      value={masterForm.name}
+                      onChange={(event) => setMasterForm((prev) => ({ ...prev, name: event.target.value }))}
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">E-mail</label>
+                    <input
+                      type="email"
+                      value={masterForm.email}
+                      onChange={(event) => setMasterForm((prev) => ({ ...prev, email: event.target.value }))}
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Senha</label>
+                    <input
+                      type="password"
+                      value={masterForm.password}
+                      onChange={(event) => setMasterForm((prev) => ({ ...prev, password: event.target.value }))}
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500"
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Máximo de usuários filhos</label>
+                      <input
+                        type="number"
+                        min={1}
+                        max={200}
+                        value={masterForm.maxChildUsers}
+                        onChange={(event) => setMasterForm((prev) => ({ ...prev, maxChildUsers: Number(event.target.value) }))}
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Limite de dispositivos por filho</label>
+                      <input
+                        type="number"
+                        min={1}
+                        max={500}
+                        value={masterForm.childDeviceLimit}
+                        onChange={(event) => setMasterForm((prev) => ({ ...prev, childDeviceLimit: Number(event.target.value) }))}
+                        className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-blue-500"
+                      />
+                    </div>
+                  </div>
+
+                  <div>
+                    <span className="block text-sm font-medium text-gray-700 mb-2">Módulos permitidos para usuários filhos</span>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                      {CHILD_VIEW_OPTIONS.map((option) => (
+                        <label key={option.id} className="flex items-center gap-2 border rounded-lg px-3 py-2 text-sm cursor-pointer hover:border-blue-400">
+                          <input
+                            type="checkbox"
+                            checked={masterForm.childAllowedViews.includes(option.id)}
+                            onChange={() => {
+                              setMasterForm((prev) => {
+                                const already = prev.childAllowedViews.includes(option.id);
+                                if (already) {
+                                  return { ...prev, childAllowedViews: prev.childAllowedViews.filter((view) => view !== option.id) };
+                                }
+                                return { ...prev, childAllowedViews: [...prev.childAllowedViews, option.id] };
+                              });
+                            }}
+                          />
+                          <span>{option.label}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <label className="block text-sm font-medium text-gray-700">Permissões adicionais</label>
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={masterForm.childCanExportReports}
+                        onChange={(event) => setMasterForm((prev) => ({ ...prev, childCanExportReports: event.target.checked }))}
+                      />
+                      Permitir exportação de relatórios pelos filhos
+                    </label>
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={masterForm.childCanManageDrivers}
+                        onChange={(event) => setMasterForm((prev) => ({ ...prev, childCanManageDrivers: event.target.checked }))}
+                      />
+                      Permitir gestão de motoristas pelos filhos
+                    </label>
+                  </div>
+
+                  <button
+                    type="submit"
+                    disabled={creatingMaster}
+                    className={`w-full inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+                      creatingMaster ? 'bg-gray-200 text-gray-400 cursor-not-allowed' : 'bg-blue-600 text-white hover:bg-blue-700'
+                    }`}
+                  >
+                    {creatingMaster ? (
+                      <>
+                        <Loader2 className="w-4 h-4 animate-spin" /> Salvando...
+                      </>
+                    ) : (
+                      <>
+                        <Plus className="w-4 h-4" /> Criar usuário mestre
+                      </>
+                    )}
+                  </button>
+                </form>
+              </section>
+            )}
+
+            <section className="bg-white border border-gray-200 rounded-xl p-6">
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Resumo da hierarquia</h3>
+              <p className="text-sm text-gray-500 mb-4">
+                Estrutura atual de usuários cadastrados no sistema.
+              </p>
+              <div className="space-y-3 text-sm">
+                <p><strong>Administrador:</strong> acesso total (apenas 1)</p>
+                <p><strong>Usuários mestre:</strong> {masters.length}</p>
+                <p><strong>Usuários filhos visíveis:</strong> {childUsers.length}</p>
+                {childOwner && (
+                  <p>
+                    <strong>Mestre selecionado:</strong> {childOwner.name} — limite restante de filhos:{' '}
+                    {remainingSlots != null ? Math.max(remainingSlots, 0) : 'ilimitado'}
+                  </p>
+                )}
+              </div>
+            </section>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/Alerts/AlertsView.tsx
+++ b/src/components/Alerts/AlertsView.tsx
@@ -5,9 +5,10 @@ import { Alert } from '../../types';
 interface AlertsViewProps {
   alerts: Alert[];
   onAcknowledgeAlert: (alertId: string) => void;
+  canAcknowledge?: boolean;
 }
 
-export const AlertsView: React.FC<AlertsViewProps> = ({ alerts, onAcknowledgeAlert }) => {
+export const AlertsView: React.FC<AlertsViewProps> = ({ alerts, onAcknowledgeAlert, canAcknowledge = true }) => {
   const [searchTerm, setSearchTerm] = useState('');
   const [filterSeverity, setFilterSeverity] = useState<string>('all');
   const [filterStatus, setFilterStatus] = useState<string>('all');
@@ -75,6 +76,11 @@ export const AlertsView: React.FC<AlertsViewProps> = ({ alerts, onAcknowledgeAle
           <span className="text-sm text-gray-600">
             {filteredAlerts.filter(a => !a.acknowledged).length} pendentes de {filteredAlerts.length}
           </span>
+          {!canAcknowledge && (
+            <span className="text-xs px-2 py-1 rounded-full bg-gray-100 text-gray-500">
+              Reconhecimento bloqueado pelo administrador
+            </span>
+          )}
         </div>
       </div>
 
@@ -185,9 +191,15 @@ export const AlertsView: React.FC<AlertsViewProps> = ({ alerts, onAcknowledgeAle
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
+                      if (!canAcknowledge) return;
                       onAcknowledgeAlert(alert.id);
                     }}
-                    className="px-3 py-1 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+                    disabled={!canAcknowledge}
+                    className={`px-3 py-1 text-sm font-medium rounded-lg transition-colors ${
+                      canAcknowledge
+                        ? 'bg-blue-600 text-white hover:bg-blue-700'
+                        : 'bg-gray-200 text-gray-400 cursor-not-allowed'
+                    }`}
                   >
                     Reconhecer
                   </button>

--- a/src/components/Auth/LoginPage.tsx
+++ b/src/components/Auth/LoginPage.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+
+interface LoginPageProps {
+  onLogin: (email: string, password: string) => Promise<void>;
+  isSubmitting?: boolean;
+  serverError?: string | null;
+}
+
+export const LoginPage: React.FC<LoginPageProps> = ({ onLogin, isSubmitting = false, serverError }) => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+
+    if (!email.trim() || !password.trim()) {
+      setError('Informe e-mail e senha para continuar.');
+      return;
+    }
+
+    setError('');
+    try {
+      await onLogin(email.trim().toLowerCase(), password);
+    } catch (err) {
+      if (!(err instanceof Error)) return;
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-blue-100 flex items-center justify-center px-4">
+      <div className="w-full max-w-md bg-white shadow-xl rounded-2xl p-8 space-y-8">
+        <div className="text-center space-y-2">
+          <div className="mx-auto h-14 w-14 rounded-full bg-blue-100 flex items-center justify-center text-blue-600 text-2xl font-semibold">
+            LK
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900">Bem-vindo ao Linka Fleet</h1>
+          <p className="text-sm text-gray-500">Acesse sua conta para monitorar sua frota em tempo real.</p>
+        </div>
+
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-5">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+                E-mail
+              </label>
+              <input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="block w-full rounded-xl border border-gray-200 px-4 py-3 text-gray-900 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                placeholder="Digite seu e-mail"
+                autoComplete="email"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+                Senha
+              </label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className="block w-full rounded-xl border border-gray-200 px-4 py-3 text-gray-900 shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                placeholder="Digite sua senha"
+                autoComplete="current-password"
+              />
+            </div>
+          </div>
+
+          {(error || serverError) && (
+            <div className="rounded-xl bg-red-50 border border-red-100 px-4 py-3 text-sm text-red-600">
+              {error || serverError}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className={`w-full inline-flex justify-center items-center rounded-xl px-4 py-3 font-semibold shadow-lg shadow-blue-200 transition-colors ${
+              isSubmitting ? 'bg-blue-300 text-white cursor-not-allowed' : 'bg-blue-600 text-white hover:bg-blue-700'
+            }`}
+          >
+            {isSubmitting ? 'Entrando...' : 'Entrar'}
+          </button>
+        </form>
+
+        <p className="text-center text-xs text-gray-400">
+          Sistema protegido. Apenas usuários autorizados podem acessar.
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -8,9 +8,22 @@ interface HeaderProps {
     role: string;
   };
   alertCount: number;
+  onLogout: () => void | Promise<void>;
 }
 
-export const Header: React.FC<HeaderProps> = ({ user, alertCount }) => {
+const roleLabels: Record<string, string> = {
+  admin: 'Administrador',
+  master: 'Usuário Mestre',
+  child: 'Usuário Filho',
+};
+
+export const Header: React.FC<HeaderProps> = ({ user, alertCount, onLogout }) => {
+  const handleLogout = () => {
+    Promise.resolve(onLogout()).catch((err) => {
+      console.warn('Erro ao encerrar sessão', err);
+    });
+  };
+
   return (
     <header className="bg-white border-b border-gray-200 px-3 sm:px-6 py-3 sm:py-4">
       <div className="flex items-center justify-between">
@@ -39,14 +52,17 @@ export const Header: React.FC<HeaderProps> = ({ user, alertCount }) => {
           <div className="flex items-center gap-2 sm:gap-3 pl-2 sm:pl-4 border-l border-gray-200">
             <div className="text-right hidden sm:block">
               <div className="text-sm font-medium text-gray-900">{user.name}</div>
-              <div className="text-xs text-gray-500 capitalize">{user.role}</div>
+              <div className="text-xs text-gray-500 capitalize">{roleLabels[user.role] || user.role}</div>
             </div>
             <div className="relative">
               <button className="flex items-center gap-2 p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors">
                 <User size={18} />
               </button>
             </div>
-            <button className="p-2 text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors">
+            <button
+              onClick={handleLogout}
+              className="p-2 text-gray-600 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+            >
               <LogOut size={18} />
             </button>
           </div>

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -17,13 +17,15 @@ interface SidebarProps {
   onViewChange: (view: string) => void;
   isCollapsed: boolean;
   onToggleCollapse: () => void;
+  allowedViews: string[];
 }
 
-export const Sidebar: React.FC<SidebarProps> = ({ 
-  activeView, 
-  onViewChange, 
-  isCollapsed, 
-  onToggleCollapse 
+export const Sidebar: React.FC<SidebarProps> = ({
+  activeView,
+  onViewChange,
+  isCollapsed,
+  onToggleCollapse,
+  allowedViews,
 }) => {
   const menuItems = [
     { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard },
@@ -36,6 +38,9 @@ export const Sidebar: React.FC<SidebarProps> = ({
     { id: 'admin', label: 'Administração', icon: Shield },
     { id: 'settings', label: 'Configurações', icon: Settings },
   ];
+
+  const visibleItems = menuItems.filter((item) => allowedViews.includes(item.id));
+  const itemsToRender = visibleItems.length ? visibleItems : menuItems;
 
   return (
     <aside className={`bg-slate-900 text-white transition-all duration-300 ${
@@ -59,10 +64,10 @@ export const Sidebar: React.FC<SidebarProps> = ({
       
       <nav className="flex-1 p-4">
         <ul className="space-y-1 sm:space-y-2">
-          {menuItems.map((item) => {
+          {itemsToRender.map((item) => {
             const Icon = item.icon;
             const isActive = activeView === item.id;
-            
+
             return (
               <li key={item.id}>
                 <button

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,216 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+export type AuthRestrictions = {
+  masterPolicies?: {
+    maxChildUsers: number;
+    childDeviceLimit: number;
+    childAllowedViews: string[];
+    childCanExportReports: boolean;
+    childCanManageDrivers: boolean;
+  };
+  allowedViews?: string[];
+  deviceLimit?: number;
+  canExportReports?: boolean;
+  canManageDrivers?: boolean;
+  canAcknowledgeAlerts?: boolean;
+};
+
+export type AuthUser = {
+  id: string;
+  name: string;
+  email: string;
+  role: 'admin' | 'master' | 'child';
+  restrictions?: AuthRestrictions;
+  parentId?: string;
+  createdAt?: string;
+  createdBy?: string;
+};
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  token: string | null;
+  isBootstrapping: boolean;
+  isSubmitting: boolean;
+  error: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  apiFetch: <T = any>(path: string, options?: RequestInit & { skipAuth?: boolean }) => Promise<T>;
+  refreshProfile: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'linka:auth';
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+async function parseJsonSafe(response: Response) {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [isBootstrapping, setIsBootstrapping] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const persistSession = useCallback((nextToken: string, nextUser: AuthUser) => {
+    setToken(nextToken);
+    setUser(nextUser);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ token: nextToken }));
+  }, []);
+
+  const clearSession = useCallback(() => {
+    setUser(null);
+    setToken(null);
+    setError(null);
+    localStorage.removeItem(STORAGE_KEY);
+  }, []);
+
+  const apiFetch = useCallback(
+    async <T,>(path: string, options: RequestInit & { skipAuth?: boolean } = {}) => {
+      const { skipAuth, headers, body, ...rest } = options;
+      const requestHeaders = new Headers(headers || {});
+
+      if (!skipAuth) {
+        if (!token) {
+          throw new Error('Sessão expirada. Faça login novamente.');
+        }
+        requestHeaders.set('Authorization', `Bearer ${token}`);
+      }
+
+      if (body && !(body instanceof FormData) && !requestHeaders.has('Content-Type')) {
+        requestHeaders.set('Content-Type', 'application/json');
+      }
+
+      const response = await fetch(`${API_BASE_URL}${path}`, {
+        ...rest,
+        headers: requestHeaders,
+        body,
+      });
+
+      if (!response.ok) {
+        const payload = await parseJsonSafe(response);
+        const message = payload?.error || response.statusText || 'Erro ao comunicar com o servidor';
+        throw new Error(message);
+      }
+
+      const payload = await parseJsonSafe(response);
+      return payload as T;
+    },
+    [token]
+  );
+
+  const refreshProfile = useCallback(async () => {
+    if (!token) {
+      setUser(null);
+      return;
+    }
+    try {
+      const data = await apiFetch<{ user: AuthUser }>(`/auth/me`);
+      setUser(data.user);
+    } catch (err) {
+      console.error('Falha ao validar sessão:', err);
+      clearSession();
+    }
+  }, [apiFetch, clearSession, token]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      setIsBootstrapping(false);
+      return;
+    }
+    try {
+      const parsed = JSON.parse(stored);
+      if (parsed?.token) {
+        setToken(parsed.token);
+        apiFetch('/auth/me', { skipAuth: true, headers: { Authorization: `Bearer ${parsed.token}` } })
+          .then((data: any) => {
+            setUser(data.user);
+            setToken(parsed.token);
+          })
+          .catch(() => {
+            clearSession();
+          })
+          .finally(() => setIsBootstrapping(false));
+        return;
+      }
+    } catch (err) {
+      console.warn('Sessão inválida no armazenamento local', err);
+    }
+    clearSession();
+    setIsBootstrapping(false);
+  }, [apiFetch, clearSession]);
+
+  useEffect(() => {
+    if (!isBootstrapping && token && !user) {
+      refreshProfile();
+    }
+  }, [isBootstrapping, token, user, refreshProfile]);
+
+  const login = useCallback(async (email: string, password: string) => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetch(`${API_BASE_URL}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      const payload = await parseJsonSafe(response);
+      if (!response.ok || !payload?.token || !payload?.user) {
+        const message = payload?.error || 'Não foi possível autenticar';
+        throw new Error(message);
+      }
+      persistSession(payload.token, payload.user);
+    } catch (err: any) {
+      const message = err?.message || 'Erro ao autenticar';
+      setError(message);
+      throw err;
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [persistSession]);
+
+  const logout = useCallback(async () => {
+    if (token) {
+      try {
+        await apiFetch('/auth/logout', { method: 'POST' });
+      } catch (err) {
+        console.warn('Erro ao finalizar sessão', err);
+      }
+    }
+    clearSession();
+  }, [apiFetch, clearSession, token]);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    user,
+    token,
+    isBootstrapping,
+    isSubmitting,
+    error,
+    login,
+    logout,
+    apiFetch,
+    refreshProfile,
+  }), [apiFetch, error, isBootstrapping, isSubmitting, login, logout, refreshProfile, token, user]);
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth deve ser utilizado dentro de um AuthProvider');
+  }
+  return ctx;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
+import { AuthProvider } from './context/AuthContext';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add backend authentication endpoints with hashed credentials, session handling, and hierarchical user creation for admin, mestre e filhos
- introduce a React auth context and login flow that persists sessions, restricts navigation per perfil e controla reconhecimento de alertas
- build an administração de usuários interface para criar mestres e filhos conforme políticas e integrar a aba no painel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3328abf648330b052e50f05e0f5b5