### PR TITLE
Route root path to login page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -193,7 +193,7 @@ const RequireAuth: React.FC<{ children: React.ReactElement }> = ({ children }) =
   }
 
   if (!user) {
-    return <Navigate to="/login" replace state={{ from: location }} />;
+    return <Navigate to="/" replace state={{ from: location }} />;
   }
 
   return children;
@@ -208,7 +208,7 @@ const LoginRoute: React.FC = () => {
   const fromLocation = (location.state as LoginLocationState | undefined)?.from;
   const redirectPath = useMemo(() => {
     if (!fromLocation?.pathname) {
-      return '/';
+      return '/app';
     }
     const search = fromLocation.search ?? '';
     const hash = fromLocation.hash ?? '';
@@ -247,9 +247,10 @@ const ProtectedAppRoute: React.FC = () => {
 function App() {
   return (
     <Routes>
-      <Route path="/login" element={<LoginRoute />} />
+      <Route path="/" element={<LoginRoute />} />
+      <Route path="/login" element={<Navigate to="/" replace />} />
       <Route
-        path="/*"
+        path="/app/*"
         element={(
           <RequireAuth>
             <ProtectedAppRoute />


### PR DESCRIPTION
## Summary
- show the login view when visiting the root URL by default
- keep the protected application under /app and adjust redirects accordingly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3517e955883309a43a6c51e960813