### PR TITLE
Integra cadastro de veículos com dispositivos do Traccar

### DIFF
--- a/backend/src/services/traccarClient.js
+++ b/backend/src/services/traccarClient.js
@@ -38,6 +38,13 @@ export const traccar = axios.create(axiosConfig);
 
 export const listDevices   = async () => (await traccar.get("/api/devices")).data;
 export const listPositions = async () => (await traccar.get("/api/positions")).data;
+export const createDevice  = async (payload = {}) => (await traccar.post("/api/devices", payload)).data;
+export const updateDevice  = async (id, payload = {}) => (await traccar.put(`/api/devices/${id}`, payload)).data;
+export const deleteDevice  = async (id) => {
+  await traccar.delete(`/api/devices/${id}`);
+  return { success: true };
+};
+
 export const listEvents = async (params = {}) => {
   try {
     const { data } = await traccar.get("/api/events", { params });

--- a/src/types/admin.ts
+++ b/src/types/admin.ts
@@ -41,6 +41,8 @@ export interface AdminVehicle {
   status: 'active' | 'inactive' | 'maintenance';
   createdAt: string;
   photo?: string; // URL or base64 of vehicle photo
+  trackerId?: string; // IMEI/uniqueId vinculado no Traccar
+  rawAttributes?: Record<string, any>;
 }
 
 export interface AdminDevice {


### PR DESCRIPTION
## Summary
- adiciona helpers e rotas para criar, atualizar e remover dispositivos no Traccar enquanto mantém os vínculos de acesso dos usuários
- atualiza a tela de gestão de veículos para consumir os dispositivos reais do Traccar, incluir o campo de IMEI/ID e salvar diretamente via API
- estende o tipo `AdminVehicle` com identificador do rastreador e atributos crus para preservar metadados do Traccar
- transforma o modal de cadastro de veículos em uma mini página lateral com cabeçalho orientativo para criar novos devices

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e36f29b9648330ab6ddd35d6c8eb91